### PR TITLE
No getcwd()

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,8 +11,12 @@
 
 from sage.all import load
 
-import os
-__endodir__ = os.getcwd() + '/heuristic_endomorphisms/'
+# by using inspect, we can set __endodir__ to the right path, and use heuristic_endomorphisms as a python module
+if not '__endodir__' in globals():
+    import os
+    import inspect
+    filename = inspect.getframeinfo(inspect.currentframe())[0];
+    __endodir__ = os.path.dirname(filename) + "/"
 
 from sage.all import *
 load(__endodir__ + "Initialize.sage");


### PR DESCRIPTION
I believe that we shouldn't be using os.getcwd().
For example, there is no good reason for the user being forced to work on the parent directory of the package.

With this pull request, the package inspect, gets the path of the `__init__.py` file, and takes care of setting the `__endodir__` to that path.

Best,
Edgar